### PR TITLE
Update Technology section

### DIFF
--- a/src/components/sections/Technology.tsx
+++ b/src/components/sections/Technology.tsx
@@ -1,7 +1,7 @@
-import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { TechnologyData } from '@/types/lp-config';
 import { Button } from '@/components/ui/Button';
+import { OptimizedImage } from '@/components/ui/OptimizedImage';
 import { sectionDefaults } from '@/config/sections';
 import { typography } from '@/config/typography';
 
@@ -53,15 +53,15 @@ function Technology({ data }: TechnologyProps) {
           </div>
 
           <div className={sectionDefaults.technology.imageContainer}>
-            <div className="relative w-full max-w-md mx-auto aspect-square rounded-2xl overflow-hidden shadow-xl">
-              <Image
-                src={data.image.src}
-                alt={data.image.alt}
-                fill
-                className="object-cover"
-                sizes="(max-width: 768px) 100vw, 400px"
-              />
-            </div>
+            <OptimizedImage
+              src={data.image.src}
+              alt={data.image.alt}
+              width={400}
+              height={400}
+              section="other"
+              className="w-full max-w-md mx-auto aspect-square rounded-2xl shadow-xl"
+              sizes="(max-width: 768px) 100vw, 400px"
+            />
           </div>
         </div>
 

--- a/src/components/ui/OptimizedImage.tsx
+++ b/src/components/ui/OptimizedImage.tsx
@@ -7,6 +7,11 @@ import { cn } from '@/lib/utils';
 interface OptimizedImageProps {
   src: string;
   alt: string;
+  /**
+   * Optionally tag the image with the section where it's used. This prop is
+   * currently informational only and has no functional effect.
+   */
+  section?: string;
   className?: string;
   priority?: boolean;
   sizes?: string;
@@ -19,6 +24,7 @@ interface OptimizedImageProps {
 export function OptimizedImage({
   src,
   alt,
+  section: _section,
   className,
   priority = false,
   sizes = '100vw',


### PR DESCRIPTION
## Summary
- replace next/image with custom OptimizedImage in Technology component
- add optional `section` prop to OptimizedImage for future tracking purposes

## Testing
- `npm run lint` *(fails: command not found)*
- `npm run type-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a0751d848329aef263bcd66cf9ab