### PR TITLE
CORREÇÃO: Restaurar imagens + otimização Unsplash

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,6 +36,34 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   compress: true,
+
+  // 🔧 CORREÇÃO PRINCIPAL: Permitir imagens externas
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: '**.googleapis.com',
+      },
+      {
+        protocol: 'https',
+        hostname: '**.googleusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'drive.google.com',
+      },
+    ],
+    formats: ['image/webp'],
+    quality: 75,
+  },
   async rewrites() {
     const clients = loadClientsFromFolders();
     

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -8,6 +8,10 @@ interface AboutProps {
 
 const About: React.FC<AboutProps> = ({ data }) => {
   const hasImage = data.image !== undefined;
+
+  const optimizedImageSrc = hasImage && data.image!.src.includes('unsplash.com')
+    ? `${data.image!.src.split('?')[0]}?w=600&q=80&auto=format&fit=crop`
+    : data.image?.src;
   
   return (
     <section
@@ -20,13 +24,14 @@ const About: React.FC<AboutProps> = ({ data }) => {
     >
       <div className="container mx-auto px-4">
         <div className="grid md:grid-cols-2 gap-12 items-center">
-          {hasImage && (
+          {hasImage && optimizedImageSrc && (
             <div className="relative w-full max-w-md mx-auto aspect-square rounded-2xl overflow-hidden shadow-xl">
               <Image
-                src={data.image!.src}
+                src={optimizedImageSrc}
                 alt={data.image!.alt}
                 fill
                 className="object-cover"
+                sizes="(max-width: 768px) 100vw, 400px"
               />
             </div>
           )}
@@ -37,7 +42,7 @@ const About: React.FC<AboutProps> = ({ data }) => {
             </h2>
 
             <div className="prose prose-lg max-w-none">
-              <p className="whitespace-pre-line">
+              <p className="whitespace-pre-line text-lg leading-relaxed">
                 {data.description}
               </p>
             </div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -15,6 +15,11 @@ function Hero({ data }: HeroProps) {
     ...(data.textColor && { color: data.textColor }),
   };
 
+  // 🔧 CORREÇÃO: URL Unsplash otimizada
+  const optimizedImageSrc = data.image.src.includes('unsplash.com')
+    ? `${data.image.src.split('?')[0]}?w=800&q=80&auto=format&fit=crop`
+    : data.image.src;
+
   return (
     <section id={data.id} className={sectionDefaults.hero.classes} style={sectionStyle}>
       <div className={sectionDefaults.hero.container}>
@@ -50,7 +55,7 @@ function Hero({ data }: HeroProps) {
           <div className={sectionDefaults.hero.imageContainer}>
             <div className="relative w-full h-[400px] md:h-[500px] rounded-2xl overflow-hidden shadow-xl">
               <Image
-                src={data.image.src}
+                src={optimizedImageSrc}
                 alt={data.image.alt}
                 fill
                 priority

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -15,6 +15,10 @@ function Services({ data }: ServicesProps) {
     ...(data.textColor && { color: data.textColor }),
   } as React.CSSProperties;
 
+  const optimizedImageSrc = data.image.src.includes('unsplash.com')
+    ? `${data.image.src.split('?')[0]}?w=600&q=80&auto=format&fit=crop`
+    : data.image.src;
+
   return (
     <section id={data.id} className={sectionDefaults.services.classes} style={sectionStyle}>
       <div className={sectionDefaults.services.container}>
@@ -34,7 +38,7 @@ function Services({ data }: ServicesProps) {
           <div className={sectionDefaults.services.imageContainer}>
             <div className="relative w-full max-w-md mx-auto aspect-square rounded-2xl overflow-hidden shadow-xl">
               <Image
-                src={data.image.src}
+                src={optimizedImageSrc}
                 alt={data.image.alt}
                 fill
                 className="object-cover"
@@ -54,9 +58,10 @@ function Services({ data }: ServicesProps) {
                 <p
                   className={cn(typography.bodyText.classes, 'mb-0')}
                   style={{ color: data.textColor }}
-                >
-                  {item.text}
-                </p>
+                  dangerouslySetInnerHTML={{
+                    __html: item.text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>'),
+                  }}
+                />
               </div>
             ))}
 

--- a/src/components/sections/Technology.tsx
+++ b/src/components/sections/Technology.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils';
 import { TechnologyData } from '@/types/lp-config';
 import { Button } from '@/components/ui/Button';
-import { OptimizedImage } from '@/components/ui/OptimizedImage';
+import Image from 'next/image';
 import { sectionDefaults } from '@/config/sections';
 import { typography } from '@/config/typography';
 
@@ -14,6 +14,10 @@ function Technology({ data }: TechnologyProps) {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
   } as React.CSSProperties;
+
+  const optimizedImageSrc = data.image.src.includes('unsplash.com')
+    ? `${data.image.src.split('?')[0]}?w=600&q=80&auto=format&fit=crop`
+    : data.image.src;
 
   return (
     <section id={data.id} className={sectionDefaults.technology.classes} style={sectionStyle}>
@@ -53,15 +57,15 @@ function Technology({ data }: TechnologyProps) {
           </div>
 
           <div className={sectionDefaults.technology.imageContainer}>
-            <OptimizedImage
-              src={data.image.src}
-              alt={data.image.alt}
-              width={400}
-              height={400}
-              section="other"
-              className="w-full max-w-md mx-auto aspect-square rounded-2xl shadow-xl"
-              sizes="(max-width: 768px) 100vw, 400px"
-            />
+            <div className="relative w-full max-w-md mx-auto aspect-square rounded-2xl overflow-hidden shadow-xl">
+              <Image
+                src={optimizedImageSrc}
+                alt={data.image.alt}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 400px"
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow external images from Unsplash and Google in `next.config.js`
- optimize Hero section image URLs
- optimize About section images
- optimize Services section images and support Markdown-style bold
- optimize Technology section images

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6873cbf4ef1c832981fcb2d0c977b957