### PR TITLE
Add pages for LP management and account settings

### DIFF
--- a/src/app/dashboard/[client]/conta/page.tsx
+++ b/src/app/dashboard/[client]/conta/page.tsx
@@ -1,0 +1,95 @@
+import { notFound } from 'next/navigation';
+import { getClientData } from '../../lib/dashboard-utils';
+import { ContaForm } from '../../components/forms/ContaForm';
+
+interface ContaPageProps {
+  params: {
+    client: string;
+  };
+}
+
+export default async function ContaPage({ params }: ContaPageProps) {
+  const clientId = params.client;
+  
+  const clientData = await getClientData(clientId);
+  if (!clientData) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Configurações da Conta</h1>
+        <p className="text-gray-600 mt-1">
+          Configure informações globais, domínio personalizado e tags de remarketing
+        </p>
+      </div>
+
+      {/* Informações atuais */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <h2 className="text-lg font-medium text-gray-900 mb-4">Configurações Atuais</h2>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-3">
+              Domínio e Acesso
+            </h3>
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Domínio:</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {clientData.domain || 'Não configurado'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Status:</span>
+                <span className={`text-sm font-medium ${
+                  clientData.active ? 'text-green-600' : 'text-red-600'
+                }`}>
+                  {clientData.active ? '🟢 Ativo' : '🔴 Inativo'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Homepage:</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {clientData.homepage || 'Não definida'}
+                </span>
+              </div>
+            </div>
+          </div>
+          
+          <div>
+            <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-3">
+              Landing Pages
+            </h3>
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Total de LPs:</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {clientData.lps ? Object.keys(clientData.lps).length : 0}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">LPs Ativas:</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {clientData.lps 
+                    ? Object.values(clientData.lps).filter((lp: any) => lp.active !== false).length 
+                    : 0
+                  }
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Formulário de edição */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <h2 className="text-lg font-medium text-gray-900 mb-6">Editar Configurações</h2>
+        <ContaForm clientId={clientId} initialData={clientData} />
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/dashboard/[client]/lps/page.tsx
+++ b/src/app/dashboard/[client]/lps/page.tsx
@@ -1,0 +1,155 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getClientData, getClientLPs } from '../../lib/dashboard-utils';
+
+interface LPsPageProps {
+  params: {
+    client: string;
+  };
+}
+
+export default async function LPsPage({ params }: LPsPageProps) {
+  const clientId = params.client;
+  
+  const clientData = await getClientData(clientId);
+  if (!clientData) {
+    notFound();
+  }
+
+  const lps = await getClientLPs(clientId);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Minhas Landing Pages</h1>
+          <p className="text-gray-600 mt-1">
+            Gerencie suas LPs, defina qual é a principal e configure o tracking
+          </p>
+        </div>
+        
+        <div className="text-sm text-gray-500">
+          Total: {lps.length} LP{lps.length !== 1 ? 's' : ''}
+        </div>
+      </div>
+
+      {/* Informações da homepage atual */}
+      {clientData.homepage && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <div className="flex items-start">
+            <div className="flex-shrink-0">
+              <svg className="h-5 w-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+            </div>
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-yellow-800">
+                Homepage Atual: {clientData.lps?.[clientData.homepage]?.title || clientData.homepage}
+              </h3>
+              <p className="text-sm text-yellow-700 mt-1">
+                Esta é a LP que aparece quando visitantes acessam seu domínio principal
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Lista de LPs */}
+      {lps.length > 0 ? (
+        <div className="grid grid-cols-1 gap-6">
+          {lps.map((lp) => (
+            <div key={lp.id} className="bg-white rounded-lg shadow-sm border border-gray-200">
+              <div className="p-6">
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center space-x-3">
+                      <h3 className="text-lg font-medium text-gray-900">
+                        {lp.title}
+                      </h3>
+                      
+                      {/* Badges de status */}
+                      <div className="flex space-x-2">
+                        {lp.isHomepage && (
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                            ⭐ Homepage
+                          </span>
+                        )}
+                        
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          lp.active 
+                            ? 'bg-green-100 text-green-800' 
+                            : 'bg-red-100 text-red-800'
+                        }`}>
+                          {lp.active ? '🟢 Ativa' : '🔴 Inativa'}
+                        </span>
+                      </div>
+                    </div>
+                    
+                    <div className="mt-2 flex items-center space-x-4 text-sm text-gray-500">
+                      <span>ID: {lp.id}</span>
+                      <span>Pasta: {lp.folder}</span>
+                      <span>URL: /{lp.slug || '(homepage)'}</span>
+                    </div>
+                    
+                    {/* URL completa */}
+                    <div className="mt-3">
+                      <p className="text-sm text-gray-600">
+                        <strong>URL de acesso:</strong>{' '}
+                        {clientData.active && clientData.domain ? (
+                          <a
+                            href={`https://${clientData.domain}${lp.slug ? `/${lp.slug}` : ''}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:text-blue-700 underline"
+                          >
+                            https://{clientData.domain}{lp.slug ? `/${lp.slug}` : ''}
+                          </a>
+                        ) : (
+                          <span className="text-gray-400">
+                            Domínio não configurado ou inativo
+                          </span>
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                  
+                  {/* Ações */}
+                  <div className="flex flex-col space-y-2 ml-6">
+                    <Link
+                      href={`/dashboard/${clientId}/lp/${lp.id}`}
+                      className="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    >
+                      ⚙️ Configurar
+                    </Link>
+                    
+                    {!lp.isHomepage && (
+                      <button
+                        className="inline-flex items-center px-3 py-2 border border-yellow-300 shadow-sm text-sm leading-4 font-medium rounded-md text-yellow-700 bg-yellow-50 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500"
+                        title="Definir como homepage"
+                      >
+                        ⭐ Tornar Principal
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        /* Estado vazio */
+        <div className="text-center py-12">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <h3 className="mt-4 text-lg font-medium text-gray-900">Nenhuma Landing Page encontrada</h3>
+          <p className="mt-2 text-gray-500">
+            Parece que ainda não há LPs configuradas para este cliente.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/dashboard/components/forms/ContaForm.tsx
+++ b/src/app/dashboard/components/forms/ContaForm.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState } from 'react';
+import { ClientData } from '../../lib/dashboard-utils';
+
+interface ContaFormProps {
+  clientId: string;
+  initialData: ClientData;
+}
+
+export function ContaForm({ clientId, initialData }: ContaFormProps) {
+  const [formData, setFormData] = useState({
+    domain: initialData.domain || '',
+    active: initialData.active ?? false,
+    homepage: initialData.homepage || '',
+    // Campos adicionais para futuras implementações
+    logoUrl: '',
+    colors: ['#FF6600', '#333333', '#007BFF'],
+    googleAdsId: '',
+    metaPixelId: '',
+    googleAnalyticsId: '',
+  });
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setMessage(null);
+
+    try {
+      // Aqui será implementada a chamada para API
+      console.log('Salvando configurações:', formData);
+      
+      // Simular delay da API
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      setMessage({ type: 'success', text: 'Configurações salvas com sucesso!' });
+    } catch (error) {
+      setMessage({ type: 'error', text: 'Erro ao salvar configurações. Tente novamente.' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (field: string, value: string | boolean) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Mensagem de feedback */}
+      {message && (
+        <div className={`p-4 rounded-md ${
+          message.type === 'success' 
+            ? 'bg-green-50 text-green-800 border border-green-200' 
+            : 'bg-red-50 text-red-800 border border-red-200'
+        }`}>
+          {message.text}
+        </div>
+      )}
+
+      {/* Seção: Domínio */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-medium text-gray-900">Domínio Personalizado</h3>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="domain" className="block text-sm font-medium text-gray-700 mb-1">
+              Domínio (sem https://)
+            </label>
+            <input
+              type="text"
+              id="domain"
+              value={formData.domain}
+              onChange={(e) => handleInputChange('domain', e.target.value)}
+              placeholder="exemplo: meudominio.com.br"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+          
+          <div className="flex items-center">
+            <label className="flex items-center">
+              <input
+                type="checkbox"
+                checked={formData.active}
+                onChange={(e) => handleInputChange('active', e.target.checked)}
+                className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+              />
+              <span className="ml-2 text-sm text-gray-700">
+                Domínio ativo (habilitar redirecionamento)
+              </span>
+            </label>
+          </div>
+        </div>
+        
+        <p className="text-sm text-gray-500">
+          Configure seu domínio personalizado. Certifique-se de que o DNS aponta para os servidores da Vercel.
+        </p>
+      </div>
+
+      {/* Seção: Configurações Visuais */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-medium text-gray-900">Configurações Visuais</h3>
+        
+        <div>
+          <label htmlFor="logoUrl" className="block text-sm font-medium text-gray-700 mb-1">
+            URL da Logo
+          </label>
+          <input
+            type="url"
+            id="logoUrl"
+            value={formData.logoUrl}
+            onChange={(e) => handleInputChange('logoUrl', e.target.value)}
+            placeholder="https://exemplo.com/logo.png"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Paleta de Cores
+          </label>
+          <div className="grid grid-cols-3 gap-2">
+            {formData.colors.map((color, index) => (
+              <input
+                key={index}
+                type="color"
+                value={color}
+                onChange={(e) => {
+                  const newColors = [...formData.colors];
+                  newColors[index] = e.target.value;
+                  setFormData(prev => ({ ...prev, colors: newColors }));
+                }}
+                className="h-10 w-full border border-gray-300 rounded-md"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Seção: Tags de Remarketing */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-medium text-gray-900">Tags de Remarketing</h3>
+        <p className="text-sm text-gray-500">
+          Configure IDs globais de remarketing que serão aplicados a todas as LPs.
+        </p>
+        
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label htmlFor="googleAdsId" className="block text-sm font-medium text-gray-700 mb-1">
+              Google Ads ID
+            </label>
+            <input
+              type="text"
+              id="googleAdsId"
+              value={formData.googleAdsId}
+              onChange={(e) => handleInputChange('googleAdsId', e.target.value)}
+              placeholder="AW-XXXXXXXXX"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+          
+          <div>
+            <label htmlFor="metaPixelId" className="block text-sm font-medium text-gray-700 mb-1">
+              Meta Pixel ID
+            </label>
+            <input
+              type="text"
+              id="metaPixelId"
+              value={formData.metaPixelId}
+              onChange={(e) => handleInputChange('metaPixelId', e.target.value)}
+              placeholder="123456789012345"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+          
+          <div>
+            <label htmlFor="googleAnalyticsId" className="block text-sm font-medium text-gray-700 mb-1">
+              Google Analytics 4 ID
+            </label>
+            <input
+              type="text"
+              id="googleAnalyticsId"
+              value={formData.googleAnalyticsId}
+              onChange={(e) => handleInputChange('googleAnalyticsId', e.target.value)}
+              placeholder="G-XXXXXXXXXX"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Botões */}
+      <div className="flex justify-end space-x-3 pt-6 border-t border-gray-200">
+        <button
+          type="button"
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          Cancelar
+        </button>
+        
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isLoading ? 'Salvando...' : 'Salvar Configurações'}
+        </button>
+      </div>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add LP list page for client dashboard
- add account settings page
- add editable account form component

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing dependencies)*
- `npm run format:check` *(fails: missing prettier plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687e5644c0a08329881d02c5bba0981b