### PR TITLE
Refactor domain API route

### DIFF
--- a/src/app/api/client/[client]/domain/route.ts
+++ b/src/app/api/client/[client]/domain/route.ts
@@ -2,6 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 
+// Interface para tipagem do domain.json
+interface DomainData {
+  domain?: string;
+  active?: boolean;
+  homepage?: string;
+  lps?: Record<string, any>;
+  plan?: string;
+  [key: string]: any;
+}
+
+
 export async function GET(
   request: NextRequest,
   { params }: { params: { client: string } }
@@ -70,7 +81,7 @@ export async function POST(
       currentData = JSON.parse(fs.readFileSync(domainPath, 'utf8'));
     }
     
-    // Atualizar dados
+    // Atualizar dados com tipagem correta
   const updatedData: DomainData = {
       ...currentData,
       domain: data.domain || currentData.domain || '',


### PR DESCRIPTION
## Summary
- reorder `DomainData` interface to the top of client domain route
- clarify POST comment

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd9bcb4708329a27e92fa62d9df9e