### PR TITLE
Update domain route and conversion detector

### DIFF
--- a/src/app/api/client/[client]/domain/route.ts
+++ b/src/app/api/client/[client]/domain/route.ts
@@ -1,8 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
-import fs from 'fs';
-import path from 'path';
+import { NextRequest, NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
 
-// Interface para tipagem do domain.json
 interface DomainData {
   domain?: string;
   active?: boolean;
@@ -49,16 +48,6 @@ export async function GET(
 }
 }
 
-// Interface para tipagem do domain.json
-interface DomainData {
-  domain?: string;
-  active?: boolean;
-  homepage?: string;
-  lps?: Record<string, any>;
-  plan?: string;
-  [key: string]: any;
-}
-
 export async function POST(
   request: NextRequest,
   { params }: { params: { client: string } }
@@ -67,30 +56,25 @@ export async function POST(
     const clientId = params.client;
     const data = await request.json();
     
-    // Validar cliente
     const clientPath = path.join(process.cwd(), 'src/app', clientId);
     if (!fs.existsSync(clientPath)) {
       return NextResponse.json({ error: 'Cliente não encontrado' }, { status: 404 });
     }
     
-    // Carregar domain.json atual
-  const domainPath = path.join(clientPath, 'domain.json');
-  let currentData: DomainData = {};
+    const domainPath = path.join(clientPath, 'domain.json');
+    let currentData: DomainData = {};
     
     if (fs.existsSync(domainPath)) {
       currentData = JSON.parse(fs.readFileSync(domainPath, 'utf8'));
     }
     
-    // Atualizar dados com tipagem correta
-  const updatedData: DomainData = {
+    const updatedData: DomainData = {
       ...currentData,
       domain: data.domain || currentData.domain || '',
       active: data.active !== undefined ? data.active : currentData.active || false,
-      // Manter outras configurações existentes
       ...data
     };
     
-    // Salvar domain.json
     fs.writeFileSync(domainPath, JSON.stringify(updatedData, null, 2), 'utf8');
     
     return NextResponse.json({ 

--- a/src/app/dashboard/components/ConversionDetector.tsx
+++ b/src/app/dashboard/components/ConversionDetector.tsx
@@ -24,7 +24,6 @@ export function ConversionDetector({ clientId, lpId, lpData }: ConversionDetecto
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
-  // ✅ CORREÇÃO: Usar useCallback para estabilizar a referência da função
   const detectConversions = useCallback(async () => {
     setIsLoading(true);
 
@@ -49,11 +48,11 @@ export function ConversionDetector({ clientId, lpId, lpData }: ConversionDetecto
     } finally {
       setIsLoading(false);
     }
-  }, [clientId, lpId, lpData]); // ✅ Todas as dependências incluídas
+  }, [clientId, lpId, lpData]);
 
   useEffect(() => {
     detectConversions();
-  }, [detectConversions]); // ✅ Agora detectConversions está estabilizada
+  }, [detectConversions]);
 
   const toggleConversion = (conversionId: string) => {
     setConversions(prev => 
@@ -169,7 +168,6 @@ export function ConversionDetector({ clientId, lpId, lpData }: ConversionDetecto
                   )}
                 </div>
                 
-                {/* Toggle */}
                 <div className="ml-4">
                   <label className="flex items-center">
                     <input
@@ -202,7 +200,6 @@ export function ConversionDetector({ clientId, lpId, lpData }: ConversionDetecto
   );
 }
 
-// Função mock para simular detecção
 function mockDetectConversions(lpData: any): DetectedConversion[] {
   const conversions: DetectedConversion[] = [];
   


### PR DESCRIPTION
## Summary
- clean up server-side domain route to remove duplicate interface and comments
- streamline `ConversionDetector` component to remove stray comments

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run format:check` *(fails: missing `prettier-plugin-tailwindcss`)*

------
https://chatgpt.com/codex/tasks/task_e_687feb89f7dc8329a3cc29073695c309