### PR TITLE
Add LP conversions editor

### DIFF
--- a/src/app/dashboard/[client]/lp/[lpId]/page.tsx
+++ b/src/app/dashboard/[client]/lp/[lpId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { getClientData, getLPData, validateLP } from '../../../lib/dashboard-utils';
-import { ConversionDetector } from '../../../components/ConversionDetector';
+import { ConversionsEditor } from '../../../components/ConversionsEditor';
 import { LPConfigForm } from '../../../components/forms/LPConfigForm';
 
 interface LPConfigPageProps {
@@ -134,8 +134,8 @@ export default async function LPConfigPage({ params }: LPConfigPageProps) {
         </div>
       </div>
 
-      {/* Detector de Conversões */}
-      <ConversionDetector 
+      {/* 🚀 NOVO: Editor de Conversões com Interface de Edição */}
+      <ConversionsEditor 
         clientId={clientId}
         lpId={lpId}
         lpData={lpData}


### PR DESCRIPTION
## Summary
- integrate new conversions editor with LP config page
- enhance ConversionsEditor with preview and validation features

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68813d40d8888329a71e5a5778c00386