### PR TITLE
Add GitHub save and deploy API

### DIFF
--- a/src/app/api/dashboard/[client]/save-and-deploy/route.ts
+++ b/src/app/api/dashboard/[client]/save-and-deploy/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { githubService } from '@/lib/github-service';
+
+interface SaveAndDeployRequest {
+  type: 'lp' | 'tracking' | 'domain';
+  lpId?: string;
+  data: any;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { client: string } }
+) {
+  if (request.method !== 'POST') {
+    return NextResponse.json({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const client = params.client;
+  const { type, lpId, data }: SaveAndDeployRequest = await request.json();
+
+  if (!client || typeof client !== 'string') {
+    return NextResponse.json({ error: 'Client ID is required' }, { status: 400 });
+  }
+
+  if (!type || !data) {
+    return NextResponse.json({ error: 'Type and data are required' }, { status: 400 });
+  }
+
+  try {
+    let filePath: string;
+    let fileContent: string;
+    let commitMessage: string;
+
+    switch (type) {
+      case 'lp':
+        if (!lpId) {
+          return NextResponse.json(
+            { error: 'LP ID is required for LP updates' },
+            { status: 400 }
+          );
+        }
+        filePath = `data/${client}/lp-${lpId}/lp.json`;
+        fileContent = JSON.stringify(data, null, 2);
+        commitMessage = `Dashboard update: LP ${lpId} content by ${client}`;
+        break;
+      case 'tracking':
+        if (!lpId) {
+          return NextResponse.json(
+            { error: 'LP ID is required for tracking updates' },
+            { status: 400 }
+          );
+        }
+        filePath = `data/${client}/lp-${lpId}/tracking.json`;
+        fileContent = JSON.stringify(data, null, 2);
+        commitMessage = `Dashboard update: LP ${lpId} tracking by ${client}`;
+        break;
+      case 'domain':
+        filePath = `data/${client}/domain.json`;
+        fileContent = JSON.stringify(data, null, 2);
+        commitMessage = `Dashboard update: Domain settings by ${client}`;
+        break;
+      default:
+        return NextResponse.json({ error: 'Invalid update type' }, { status: 400 });
+    }
+
+    const result = await githubService.updateFile({
+      path: filePath,
+      content: fileContent,
+      message: commitMessage,
+    });
+
+    if (result.success) {
+      return NextResponse.json({
+        success: true,
+        message: 'Changes deployed successfully',
+        commit: result.commit,
+        deployUrl: `https://lp-factory-v2-robusto.vercel.app`,
+      });
+    }
+
+    return NextResponse.json(
+      { success: false, error: result.error, message: 'Failed to deploy changes' },
+      { status: 500 }
+    );
+  } catch (error) {
+    console.error('Save and deploy error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Internal server error', message: 'Failed to save and deploy changes' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/dashboard-api.ts
+++ b/src/lib/dashboard-api.ts
@@ -1,0 +1,44 @@
+interface SaveAndDeployOptions {
+  client: string;
+  type: 'lp' | 'tracking' | 'domain';
+  lpId?: string;
+  data: any;
+}
+
+export async function saveAndDeploy(options: SaveAndDeployOptions) {
+  const { client, type, lpId, data } = options;
+
+  const response = await fetch(`/api/dashboard/${client}/save-and-deploy`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ type, lpId, data }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.message || 'Failed to save and deploy');
+  }
+
+  return response.json();
+}
+
+export function createDebouncedSaveAndDeploy(delay = 3000) {
+  let timeoutId: NodeJS.Timeout;
+
+  return function (options: SaveAndDeployOptions) {
+    return new Promise((resolve, reject) => {
+      clearTimeout(timeoutId);
+
+      timeoutId = setTimeout(async () => {
+        try {
+          const result = await saveAndDeploy(options);
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        }
+      }, delay);
+    });
+  };
+}

--- a/src/lib/github-service.ts
+++ b/src/lib/github-service.ts
@@ -1,0 +1,129 @@
+interface GitHubConfig {
+  token: string;
+  owner: string;
+  repo: string;
+}
+
+interface UpdateFileParams {
+  path: string;
+  content: string;
+  message: string;
+}
+
+interface GitHubResponse {
+  success: boolean;
+  commit?: string;
+  error?: string;
+}
+
+class GitHubService {
+  private config: GitHubConfig;
+  private baseUrl = 'https://api.github.com';
+
+  constructor() {
+    this.config = {
+      token: process.env.GITHUB_TOKEN || '',
+      owner: process.env.GITHUB_REPO_OWNER || '',
+      repo: process.env.GITHUB_REPO_NAME || '',
+    };
+
+    if (!this.config.token || !this.config.owner || !this.config.repo) {
+      console.error('GitHub configuration missing. Check environment variables.');
+    }
+  }
+
+  private async makeRequest(endpoint: string, options: RequestInit = {}): Promise<any> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${this.config.token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`GitHub API error: ${response.status} - ${errorText}`);
+    }
+
+    return response.json();
+  }
+
+  private async getFileContent(path: string): Promise<{ content: string; sha: string } | null> {
+    try {
+      const response = await this.makeRequest(
+        `/repos/${this.config.owner}/${this.config.repo}/contents/${path}`
+      );
+
+      return {
+        content: Buffer.from(response.content, 'base64').toString('utf-8'),
+        sha: response.sha,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async updateFile(params: UpdateFileParams): Promise<GitHubResponse> {
+    const { path, content, message } = params;
+
+    try {
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+          const existingFile = await this.getFileContent(path);
+          const requestBody: any = {
+            message,
+            content: Buffer.from(content).toString('base64'),
+            branch: 'main',
+          };
+
+          if (existingFile) {
+            requestBody.sha = existingFile.sha;
+          }
+
+          const response = await this.makeRequest(
+            `/repos/${this.config.owner}/${this.config.repo}/contents/${path}`,
+            {
+              method: 'PUT',
+              body: JSON.stringify(requestBody),
+            }
+          );
+
+          return {
+            success: true,
+            commit: response.commit.sha,
+          };
+        } catch (error) {
+          console.error(`GitHub API attempt ${attempt} failed:`, error);
+          if (attempt === 3) {
+            throw error;
+          }
+          await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt - 1) * 1000));
+        }
+      }
+
+      return { success: false, error: 'All retry attempts failed' };
+    } catch (error) {
+      console.error('GitHub service error:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  async validateConnection(): Promise<boolean> {
+    try {
+      await this.makeRequest(`/repos/${this.config.owner}/${this.config.repo}`);
+      return true;
+    } catch (error) {
+      console.error('GitHub connection validation failed:', error);
+      return false;
+    }
+  }
+}
+
+export const githubService = new GitHubService();


### PR DESCRIPTION
## Summary
- add GitHub service with update helper
- expose dashboard API utilities for saving data
- implement `save-and-deploy` API endpoint using Next.js route handlers

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6881637439248329a6d7ffc9b6874eb3